### PR TITLE
Django 2.2: Access user.is_authenticated as property

### DIFF
--- a/django_force_logout/middleware.py
+++ b/django_force_logout/middleware.py
@@ -18,7 +18,7 @@ class ForceLogoutMiddleware(MiddlewareMixin):
         self.get_response = get_response
 
     def process_request(self, request):
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return
 
         user_timestamp = self.fn(request.user)


### PR DESCRIPTION
When running with Django 2.2 the following error is seen:
```
  File "/Users/daniel/.virtualenvs/allears/lib/python3.8/site-packages/django_force_logout/middleware.py", line 21, in process_request
    if not request.user.is_authenticated():
TypeError: 'bool' object is not callable
```
